### PR TITLE
Update Web.config

### DIFF
--- a/GolfTracker.WebApi/Web.config
+++ b/GolfTracker.WebApi/Web.config
@@ -18,6 +18,7 @@
     <add key="authkey" value="your DocumentDB authkey" />
     <add key="db" value="GolfTracker" />
     <add key="userCollection" value="Users" />
+    <add key="mainCollection" value="GolfCollection" />
     <!-- This is used as the base Url for the ConfirmEmail link in the email sent after Sign Up. -->
     <add key="ClientSite" value="http://localhost:60528" />
   </appSettings>


### PR DESCRIPTION
Addition of key for naming mainCollection, that is used for storing most documents, directly into config file (alternatively, if you wanted to save everything to one collection you set mainCollection and userCollection to the same value). Previously "GolfCollection" was hard coded. Also sets up ability to allow you to change the setting via the Azure Portal.

Part 1 of moving key to config.
