### PR TITLE
Update ApplicationOAuthProvider.cs

### DIFF
--- a/GolfTracker.WebApi/Providers/ApplicationOAuthProvider.cs
+++ b/GolfTracker.WebApi/Providers/ApplicationOAuthProvider.cs
@@ -28,11 +28,30 @@ namespace GolfTracker.WebApi.Providers
 
         public override async Task GrantResourceOwnerCredentials(OAuthGrantResourceOwnerCredentialsContext context)
         {
-            // http://www.codeproject.com/Articles/742532/Using-Web-API-Individual-User-Account-plus-CORS-En
-            // This article helped me track down the issue that even though CORS is enabled application-wide, 
-            // it still doesn't affect this OWIN component, so we have to enable it here also.
+            // For best practices, you should use always use a dynamic access-control-allow-origin response.
+            
+            // Get the Allowed Origins from Helper
             string origins = AppSettingsConfig.CorsPolicyOrigins;
-            context.OwinContext.Response.Headers.Add("Access-Control-Allow-Origin", new string[] { origins });
+            
+            // Get the Origin of the Request
+            string requestOrigin = context.OwinContext.Request.Headers.Get("origin");
+
+            // If the Origin of the Request is contained in the Allowed Origins Set Access-Control-Allow-Origin for that Origin only.
+            if (origins.Contains(requestOrigin))
+            {
+                context.OwinContext.Response.Headers.Add("Access-Control-Allow-Origin", new string[] { requestOrigin });
+            }
+
+            // http://www.codeproject.com/Articles/742532/Using-Web-API-Individual-User-Account-plus-CORS-En
+            // "This article helped me track down the issue that even though CORS is enabled application-wide, 
+            // it still doesn't affect this OWIN component, so we have to enable it here also."
+            
+            // NOTE :: Only works when Allowed Origins is a single URI (not a comma separated list).
+            //string origins = AppSettingsConfig.CorsPolicyOrigins;
+            //context.OwinContext.Response.Headers.Add("Access-Control-Allow-Origin", new string[] { origins });
+
+            // Allow All Sample - Not recommended unless you are intentionally accepting requests from unknown origins.
+            //context.OwinContext.Response.Headers.Add("Access-Control-Allow-Origin", new string[] { "*" });
 
             var userManager = context.OwinContext.GetUserManager<ApplicationUserManager>();
 


### PR DESCRIPTION
Fixes issue within OWIN when using multiple allowed origins for cross-origin resource sharing. This affected calls to the WebAPI "/token" endpoint when requesting a bearer token. Thus, what would occur before was that the key "Access-Control-Allow-Origin" would return a value that was set to the entire string, including comma that was used within the config file. Which would yield an error when trying to access from any of the origins in the config file. Everything got treated as one long URI instead of two independent URIs.

The fix gets the origin from the config, but then now also grabs the origin value from the request before checking to make sure the allowed origins string contains the origin from the request. Then dynamically serves back that origin as an allowed origin within the response headers.

Comments are added to keep things neat with the original code still in place with an additional line added to demonstrate handling all origins with a "*" value passed with the "Access-Control-Allow-Origin" key.
