### PR TITLE
Update MyCustomCorsPolicyProvider.cs

### DIFF
--- a/GolfTracker.WebApi/Cors/MyCustomCorsPolicyProvider.cs
+++ b/GolfTracker.WebApi/Cors/MyCustomCorsPolicyProvider.cs
@@ -17,14 +17,19 @@ namespace GolfTracker.WebApi.Cors
             {
                 AllowAnyHeader = true,
                 AllowAnyMethod = true
+                // Optionally ::
+                //,AllowAnyOrigin = true
             };
+            
+            // Get Allowed Origins from Config and split by comma. Can be changed to any character that you chose.
+            string[] origins = AppSettingsConfig.CorsPolicyOrigins.Split(',');
+            
+            // To split by multiple types use the following example as a template:
+            // string[] origins = AppSettingsCOnfig.CorsPolicyOrigins.Split(',','+');
 
-            string origins = AppSettingsConfig.CorsPolicyOrigins;
-            string[] originsList = origins.Split(',');
-
-            foreach (var item in originsList)
+            foreach (var origin in origins)
             {
-                corsPolicy.Origins.Add(item);
+                corsPolicy.Origins.Add(origin);
             }
 
             return Task.FromResult(corsPolicy);


### PR DESCRIPTION
Adds some comments and simplifies the code slightly to remove the extra variable. The change sets the array directly without an intermediate variable.

Example template included in comments for implementing multiple delimiters when splitting the allowed origins string from the config file.

Also shows the AllowAnyOrigin boolean variable that can be set when instantiating a new CorsPolicy().
